### PR TITLE
Readme example fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ const colors = [
 const characterName: string = uniqueNamesGenerator({
   dictionaries: [colors, starWarsCharacters],
   length: 2,
-  space: ' '
+  separator: ' '
 }); // Green Luke Skywalker
 ```
 
@@ -210,7 +210,7 @@ const xMen = [
 const characterName: string = uniqueNamesGenerator({
   dictionaries: [improvedAdjectives, xMen],
   length: 2,
-  space: '-'
+  separator: '-'
 }); // eccentric-iceman
 ```
 

--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ The default dictionaries are provided in the following order: `adjectives, color
 import { uniqueNamesGenerator, adjectives, colors, animals } from 'unique-names-generator';
 
 const shortName: string = uniqueNamesGenerator({
-  dictionaries: [color, adjectives, animal]
+  dictionaries: [colors, adjectives, animals]
 }); // red_big_donkey
 ```
 


### PR DESCRIPTION
There were two fixes needed in readme of package when i was going through them

1. The options config in example were mistyped as singulars (colors as color) etc
2. Two times space option in config is used which doesn't exist, hence it is replaced with 'separator'