### PR TITLE
fix(dictionaries): add “countries” to import/export list

### DIFF
--- a/src/dictionaries/index.ts
+++ b/src/dictionaries/index.ts
@@ -1,7 +1,8 @@
 import adjectives from './adjectives';
 import animals from './animals';
 import colors from './colors';
+import countries from './countries';
 import names from './names';
 import starWars from './star-wars';
 
-export { adjectives, animals, colors, names, starWars };
+export { adjectives, animals, colors, countries, names, starWars };


### PR DESCRIPTION
The `countries` dictionary is missing from the `index.ts` file.