### PR TITLE
Config now accepts seed used to deterministically generate name

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ If you want to migrate, from an older version of the library to v4, please read 
       - [separator](#separator)
       - [length](#length)
       - [style](#style)
+      - [seed](#seed)
   - [Dictionaries available](#dictionaries-available)
       - [Adjectives](#adjectives)
       - [Animals](#animals)
@@ -220,6 +221,14 @@ const lowerCaseName: string = uniqueNamesGenerator({
   style: 'capital'
 }); // red_big_donkey
 ```
+
+#### seed
+
+Type: `number`
+
+required: `false`
+
+A seed is used when wanting to deterministically generate a name. As long as the provided seed is the same the generated name will also always be the same.
 
 ## Dictionaries available
 

--- a/src/unique-names-generator.constructor.test.ts
+++ b/src/unique-names-generator.constructor.test.ts
@@ -135,6 +135,33 @@ describe('randomNameGenerator', () => {
     expect(expected).toMatch(/^Adjective[123]-Animal[123]$/);
   });
 
+  it('should generate the same name given an equal seed', () => {
+    // Arrange
+    const adjectives = ['Adjective1', 'Adjective2', 'Adjective3'];
+    const colors = ['Color1', 'Color2', 'Color3'];
+    const subjects = ['Animal1', 'Animal2', 'Animal3'];
+    const config: Config = {
+      dictionaries: [adjectives, subjects, colors],
+      separator: '-',
+      seed: 120498,
+    };
+
+    // Act
+    let uniqueNamesGenerator = new UniqueNamesGenerator(config);
+    const name1 = uniqueNamesGenerator.generate();
+    uniqueNamesGenerator = new UniqueNamesGenerator(config);
+    const name2 = uniqueNamesGenerator.generate();
+    uniqueNamesGenerator = new UniqueNamesGenerator(config);
+    const name3 = uniqueNamesGenerator.generate();
+    uniqueNamesGenerator = new UniqueNamesGenerator(config);
+    const name4 = uniqueNamesGenerator.generate();
+
+    // Assert
+    expect(name1).toEqual(name2);
+    expect(name1).toEqual(name3);
+    expect(name1).toEqual(name4);
+  });
+
   it('should throw an error when there are no dictionaries', () => {
     // Arrange
     const config = {

--- a/src/unique-names-generator.constructor.ts
+++ b/src/unique-names-generator.constructor.ts
@@ -10,6 +10,7 @@ export interface Config {
   separator?: string;
   length?: number;
   style?: Style;
+  seed?: number;
 }
 
 export class UniqueNamesGenerator {
@@ -17,14 +18,16 @@ export class UniqueNamesGenerator {
   private length: number;
   private separator: string;
   private style: Style;
+  private seed: number;
 
   constructor(config: Config) {
-    const { length, separator, dictionaries, style } = config;
+    const { length, separator, dictionaries, style, seed } = config;
 
     this.dictionaries = dictionaries;
     this.separator = separator;
     this.length = length;
     this.style = style;
+    this.seed = seed;
   }
 
   public generate(): string {
@@ -47,7 +50,9 @@ export class UniqueNamesGenerator {
     }
 
     return this.dictionaries.slice(0, this.length).reduce((acc: string, curr: string[]) => {
-      const rnd = Math.floor(Math.random() * curr.length);
+      const rnd = Math.floor(
+        (this.seed ? this.mulberry32(this.seed)() : Math.random()) * curr.length,
+      );
       let word = curr[rnd] || '';
 
       if (this.style === 'lowerCase') {
@@ -61,5 +66,15 @@ export class UniqueNamesGenerator {
 
       return acc ? `${acc}${this.separator}${word}` : `${word}`;
     }, '');
+  }
+
+  private mulberry32(seed: number): () => number {
+    return (): number => {
+      seed |= 0;
+      seed = (seed + 0x6d2b79f5) | 0;
+      let t = Math.imul(seed ^ (seed >>> 15), 1 | seed);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
   }
 }


### PR DESCRIPTION
I wanted to be able to deterministically generate names based on uuid's. So I've added a seed value to the config which will let you always generate the same name given that the provided seed is the same.

Read more about the used seeded random function at https://github.com/bryc/code/blob/master/jshash/PRNGs.md