### PR TITLE
fix: do not use the same seed for every dictionary

### DIFF
--- a/src/unique-names-generator.constructor.ts
+++ b/src/unique-names-generator.constructor.ts
@@ -51,8 +51,17 @@ export class UniqueNamesGenerator {
       );
     }
 
+    let seed = this.seed;
+
     return this.dictionaries.slice(0, this.length).reduce((acc: string, curr: string[]) => {
-      const rnd = Math.floor((this.seed ? getFromSeed(this.seed) : Math.random()) * curr.length);
+      let randomFloat;
+      if (seed) {
+        randomFloat = getFromSeed(seed);
+        seed = randomFloat * 4294967296;
+      } else {
+        randomFloat = Math.random();
+      }
+      const rnd = Math.floor(randomFloat * curr.length);
       let word = curr[rnd] || '';
 
       if (this.style === 'lowerCase') {


### PR DESCRIPTION
Now the user-provided seed is used for the first dictionary, and a new seed is derived from that one for the next dictionary. This drastically increases the number of possible combinations.

Fix #53