### PR TITLE
Improve String-to-Number Conversion Logic in Seed Handling

### DIFF
--- a/src/unique-names-generator.constructor.ts
+++ b/src/unique-names-generator.constructor.ts
@@ -36,10 +36,16 @@ export class UniqueNamesGenerator {
 
   #convertSeed(seed: number | string): number {
     if (typeof seed === 'string') {
-      const numberFromString = seed.split('').reduce((acc, curr) => acc + curr.charCodeAt(0), 1);
-
-      const numericSeed = Math.floor(Number(numberFromString));
-      return numericSeed;
+      let hash = 0;
+      if (seed.length === 0) return hash;
+      const maxSafeLength = 16;
+      for (let i = 0; i < Math.min(seed.length, maxSafeLength); i++) {
+        const char = seed.charCodeAt(i);
+        // prettier-ignore
+        hash = ((hash << 5) - hash) + char;
+        hash |= 0; // Convert to 32bit integer
+      }
+      return Math.abs(hash);
     }
     return seed;
   }


### PR DESCRIPTION
This Pull Request introduces an optimized and potentially more collision-resistant string-to-number conversion method in the seed-handling logic.

**Before**:
With the current logic, different string seeds might result in the same numeric seed if the sum of their character codes is the same. For example:

"AB" would be converted to 138 because 'A' has a character code of 65, ' B' has a character code of 66, and 65 + 66 + 1 (the initial accumulator value) is 132.
"BA" would also be converted to 132 for the same reason.

Example:
```
const seed = "BA"; // Try changing this to "AB" and you'll get the same result
const numberFromString = seed.split('').reduce((acc, curr) => acc + curr.charCodeAt(0), 1);
const numericSeed = Math.floor(Number(numberFromString));
console.log(numericSeed); // Output: 132
```

**Now**:
A straightforward improvement to the hashing function enhances its capacity to disperse different input strings to a broader range of output values, thus reducing collisions.


